### PR TITLE
Loosen React peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build": "yarn lint && tsc --project tsconfig.json"
   },
   "peerDependencies": {
-    "react": "16.11.0",
+    "react": ">=16.11.0",
     "react-native": ">=0.59.0"
   },
   "devDependencies": {


### PR DESCRIPTION
React Native 0.63.x uses already React 17.0.1, so we don't want to fix our dependency at 16.11.0, but rather be more flexible.

Fixes: https://github.com/brains-and-beards/react-native-animated-code-input/issues/12